### PR TITLE
Move facebook/php-sdk to require-dev

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,11 +14,11 @@
 	],
 	"require": {
 		"php": ">=5.3.0",
-		"facebook/php-sdk": "3.2.*",
 		"composer/installers": "*",
 		"openbuildings/jam": "0.4.*"
 	},
 	"require-dev": {
+		"facebook/php-sdk": "3.2.*",
 		"openbuildings/kohana-test-bootsrap": "0.1.*"
 	}
 }

--- a/composer.lock
+++ b/composer.lock
@@ -1,9 +1,10 @@
 {
     "_readme": [
         "This file locks the dependencies of your project to a known state",
-        "Read more about it at http://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file"
+        "Read more about it at http://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
+        "This file is @generated automatically"
     ],
-    "hash": "55edfe7707987b6fa2253c7fa441dfd8",
+    "hash": "f9ad5e3592864190bb57254602268e14",
     "packages": [
         {
             "name": "composer/installers",
@@ -11,12 +12,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/composer/installers.git",
-                "reference": "v1.0.5"
+                "reference": "5bad5563431576e1b318c7326c0e61c6567000bd"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/composer/installers/zipball/v1.0.5",
-                "reference": "v1.0.5",
+                "url": "https://api.github.com/repos/composer/installers/zipball/5bad5563431576e1b318c7326c0e61c6567000bd",
+                "reference": "5bad5563431576e1b318c7326c0e61c6567000bd",
                 "shasum": ""
             },
             "replace": {
@@ -78,60 +79,17 @@
             "time": "2013-08-07 17:25:08"
         },
         {
-            "name": "facebook/php-sdk",
-            "version": "v3.2.2",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/facebook/facebook-php-sdk.git",
-                "reference": "v3.2.2"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/facebook/facebook-php-sdk/zipball/v3.2.2",
-                "reference": "v3.2.2",
-                "shasum": ""
-            },
-            "require": {
-                "ext-curl": "*",
-                "ext-json": "*",
-                "php": ">=5.2.0"
-            },
-            "type": "library",
-            "autoload": {
-                "classmap": [
-                    "src"
-                ]
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "Apache2"
-            ],
-            "authors": [
-                {
-                    "name": "Facebook",
-                    "homepage": "https://github.com/facebook/facebook-php-sdk/contributors"
-                }
-            ],
-            "description": "Facebook PHP SDK",
-            "homepage": "https://github.com/facebook/facebook-php-sdk",
-            "keywords": [
-                "facebook",
-                "sdk"
-            ],
-            "time": "2013-01-15 21:37:15"
-        },
-        {
             "name": "openbuildings/flex-storage",
-            "version": "v0.1.2",
+            "version": "0.1.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/OpenBuildings/flex-storage.git",
-                "reference": "v0.1.2"
+                "reference": "780d09228a3e4e5a3086c1f55592304502efe987"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/OpenBuildings/flex-storage/zipball/v0.1.2",
-                "reference": "v0.1.2",
+                "url": "https://api.github.com/repos/OpenBuildings/flex-storage/zipball/780d09228a3e4e5a3086c1f55592304502efe987",
+                "reference": "780d09228a3e4e5a3086c1f55592304502efe987",
                 "shasum": ""
             },
             "require": {
@@ -156,7 +114,7 @@
                 }
             ],
             "description": "Flexible storage provider for files (rackspace, aws, ftp, local)",
-            "time": "2013-08-14 07:24:02"
+            "time": "2014-07-08 12:07:06"
         },
         {
             "name": "openbuildings/jam",
@@ -164,12 +122,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/OpenBuildings/jam.git",
-                "reference": "0.4.0"
+                "reference": "b43b705bab91753db758643479a466f28e22be15"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/OpenBuildings/jam/zipball/0.4.0",
-                "reference": "0.4.0",
+                "url": "https://api.github.com/repos/OpenBuildings/jam/zipball/b43b705bab91753db758643479a466f28e22be15",
+                "reference": "b43b705bab91753db758643479a466f28e22be15",
                 "shasum": ""
             },
             "require": {
@@ -211,12 +169,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/rackspace/php-opencloud.git",
-                "reference": "V1.5.10"
+                "reference": "f4c4bbbae8b108c572b346a7cd350c62122451d5"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/rackspace/php-opencloud/zipball/V1.5.10",
-                "reference": "V1.5.10",
+                "url": "https://api.github.com/repos/rackspace/php-opencloud/zipball/f4c4bbbae8b108c572b346a7cd350c62122451d5",
+                "reference": "f4c4bbbae8b108c572b346a7cd350c62122451d5",
                 "shasum": ""
             },
             "require": {
@@ -240,7 +198,8 @@
                 },
                 {
                     "name": "Jamie Hannaford",
-                    "email": "jamie@limetree.org"
+                    "email": "jamie.hannaford@rackspace.com",
+                    "homepage": "https://github.com/jamiehannaford"
                 }
             ],
             "description": "Rackspace open cloud php library",
@@ -253,17 +212,64 @@
     ],
     "packages-dev": [
         {
+            "name": "facebook/php-sdk",
+            "version": "v3.2.3",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/facebookarchive/facebook-php-sdk.git",
+                "reference": "6714042fa2f5979d4c64c7d11fb4bcab16bdf6cb"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/facebookarchive/facebook-php-sdk/zipball/6714042fa2f5979d4c64c7d11fb4bcab16bdf6cb",
+                "reference": "6714042fa2f5979d4c64c7d11fb4bcab16bdf6cb",
+                "shasum": ""
+            },
+            "require": {
+                "ext-curl": "*",
+                "ext-json": "*",
+                "php": ">=5.2.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "3.7.*"
+            },
+            "type": "library",
+            "autoload": {
+                "classmap": [
+                    "src"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "Apache2"
+            ],
+            "authors": [
+                {
+                    "name": "Facebook",
+                    "homepage": "https://github.com/facebook/facebook-php-sdk/contributors"
+                }
+            ],
+            "description": "Facebook PHP SDK",
+            "homepage": "https://github.com/facebook/facebook-php-sdk",
+            "keywords": [
+                "facebook",
+                "sdk"
+            ],
+            "abandoned": "facebook/php-sdk-v4",
+            "time": "2013-11-19 23:11:14"
+        },
+        {
             "name": "openbuildings/kohana-test-bootsrap",
             "version": "0.1.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/OpenBuildings/kohana-test-bootstrap.git",
-                "reference": "0.1.0"
+                "reference": "00f1f6dad4a755662c5c77b3739d248614bab15d"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/OpenBuildings/kohana-test-bootstrap/zipball/0.1.0",
-                "reference": "0.1.0",
+                "url": "https://api.github.com/repos/OpenBuildings/kohana-test-bootstrap/zipball/00f1f6dad4a755662c5c77b3739d248614bab15d",
+                "reference": "00f1f6dad4a755662c5c77b3739d248614bab15d",
                 "shasum": ""
             },
             "type": "library",
@@ -288,17 +294,12 @@
             "time": "2013-08-12 09:28:25"
         }
     ],
-    "aliases": [
-
-    ],
+    "aliases": [],
     "minimum-stability": "stable",
-    "stability-flags": [
-
-    ],
+    "stability-flags": [],
+    "prefer-stable": false,
     "platform": {
         "php": ">=5.3.0"
     },
-    "platform-dev": [
-
-    ]
+    "platform-dev": []
 }


### PR DESCRIPTION
`facebook/php-sdk` is not needed if you don't use the Facebook service.
