### PR TITLE
Extract "username" into a behaviour

### DIFF
--- a/auth-schema-mysql.sql
+++ b/auth-schema-mysql.sql
@@ -27,7 +27,6 @@ CREATE TABLE IF NOT EXISTS `users` (
   `twitter_uid` varchar(100),
   `last_login_ip` VARCHAR(40),
   PRIMARY KEY  (`id`),
-  UNIQUE KEY `uniq_username` (`username`),
   UNIQUE KEY `uniq_email` (`email`)
 ) ENGINE=InnoDB  DEFAULT CHARSET=utf8;
 

--- a/classes/Jam/Behavior/Username.php
+++ b/classes/Jam/Behavior/Username.php
@@ -1,0 +1,3 @@
+<?php defined('SYSPATH') OR die('No direct script access.');
+
+class Jam_Behavior_Username extends Kohana_Jam_Behavior_Username {}

--- a/classes/Kohana/Jam/Behavior/Username.php
+++ b/classes/Kohana/Jam/Behavior/Username.php
@@ -1,0 +1,28 @@
+<?php defined('SYSPATH') OR die('No direct access allowed.');
+/**
+ * @package    Jam
+ * @category   Behavior
+ * @author     Ivan Kerin
+ * @copyright  (c) 2011-2012 Despark Ltd.
+ * @license    http://www.opensource.org/licenses/isc-license.txt
+ */
+class Kohana_Jam_Behavior_Username extends Jam_Behavior {
+
+	public function initialize(Jam_Meta $meta, $name)
+	{
+		parent::initialize($meta, $name);
+
+		$meta
+			->name_key('username')
+
+			->fields([
+				'username' => Jam::field('string'),
+			])
+
+			->validator('username', array(
+				'length' => array('minimum' => 3, 'maximum' => 32),
+				'present' => TRUE,
+				'format' => array('regex' => '/^[a-zA-Z0-9\_\-]+$/')
+			));
+	}
+}

--- a/classes/Kohana/Jam/Behavior/Username.php
+++ b/classes/Kohana/Jam/Behavior/Username.php
@@ -13,6 +13,8 @@ class Kohana_Jam_Behavior_Username extends Jam_Behavior {
 		parent::initialize($meta, $name);
 
 		$meta
+			->unique_key(array($this, 'username_key'))
+
 			->name_key('username')
 
 			->fields([
@@ -25,4 +27,10 @@ class Kohana_Jam_Behavior_Username extends Jam_Behavior {
 				'format' => array('regex' => '/^[a-zA-Z0-9\_\-]+$/')
 			));
 	}
+
+	public function username_key($value)
+	{
+		return Valid::email($value) ? 'email' : ((is_numeric($value) OR $value === NULL) ? 'id' : 'username');
+	}
+
 }

--- a/classes/Kohana/Model/Auth/User.php
+++ b/classes/Kohana/Model/Auth/User.php
@@ -1,7 +1,7 @@
 <?php defined('SYSPATH') OR die('No direct access allowed.');
 /**
  * Default auth user.
- * 
+ *
  * @package	   Kohana/Auth
  * @author     Ivan Kerin
  * @copyright  (c) 2011-2012 Despark Ltd.
@@ -16,7 +16,7 @@ class Kohana_Model_Auth_User extends Jam_Model {
 	public static function initialize(Jam_Meta $meta)
 	{
 		$meta
-			->name_key('username')
+			->name_key('email')
 
 			->associations(array(
 				'user_tokens' => Jam::association('hasmany'),
@@ -28,7 +28,6 @@ class Kohana_Model_Auth_User extends Jam_Model {
 				'email' => Jam::field('string', array(
 					'label' => 'email address',
 				)),
-				'username' => Jam::field('string'),
 				'password' => Jam::field('password', array(
 					'hash_with' => array(Auth::instance(), 'hash'),
 				)),
@@ -43,15 +42,9 @@ class Kohana_Model_Auth_User extends Jam_Model {
 				'last_login_ip' => Jam::field('string', array('label' => 'Last logged from')),
 			))
 
-		
 			->validator('email', array(
 				'format' => array('email' => TRUE),
 				'unique' => TRUE
-			))
-			->validator('username', array(
-				'length' => array('minimum' => 3, 'maximum' => 32),
-				'present' => TRUE,
-				'format' => array('regex' => '/^[a-zA-Z0-9\_\-]+$/')
 			))
 			->validator('password', array(
 				'length' => array('minimum' => 5, 'maximum' => 30),
@@ -73,7 +66,7 @@ class Kohana_Model_Auth_User extends Jam_Model {
 
 	public static function unique_key($value)
 	{
-		return Valid::email($value) ? 'email' : ((is_numeric($value) OR $value === NULL) ? 'id' : 'username');
+		return (is_numeric($value) OR $value === NULL) ? 'id' : 'email';
 	}
 
 	/**
@@ -98,7 +91,7 @@ class Kohana_Model_Auth_User extends Jam_Model {
 
 	public function load_service_values(Auth_Service $service, array $user_data, $create = FALSE)
 	{
-		
+
 	}
 
 	public function build_user_token(array $values = array())
@@ -107,7 +100,7 @@ class Kohana_Model_Auth_User extends Jam_Model {
 			'expires' => time() + Kohana::$config->load('auth.lifetime'),
 		), $values))->generate_unique_token();
 	}
-	
+
 	public function has_facebook()
 	{
 		return (bool) $this->facebook_uid;

--- a/tests/classes/Model/Test/User.php
+++ b/tests/classes/Model/Test/User.php
@@ -8,6 +8,11 @@ class Model_Test_User extends Model_Auth_User {
 
 		parent::initialize($meta);
 
+		$meta
+			->behaviors([
+				'username' => Jam::behavior('username'),
+			]);
+
 		$meta->associations(array(
 			'user_tokens' => Jam::association('hasmany', array('foreign_model' => 'test_user_token', 'foreign_key' => 'test_user_id')),
 			'roles' => Jam::association('manytomany', array(

--- a/tests/database/structure/mysql.sql
+++ b/tests/database/structure/mysql.sql
@@ -41,6 +41,5 @@ CREATE TABLE `test_users` (
   `twitter_uid` varchar(100),
   `last_login_ip` VARCHAR(40),
   PRIMARY KEY  (`id`),
-  UNIQUE KEY `uniq_username` (`username`),
   UNIQUE KEY `uniq_email` (`email`)
 ) ENGINE=InnoDB  DEFAULT CHARSET=utf8;

--- a/tests/tests/auth/JamTest.php
+++ b/tests/tests/auth/JamTest.php
@@ -38,7 +38,6 @@ class Auth_JamTest extends Testcase_Auth {
 
 		return array(
 			array(array(NULL, 'qweqwe'), TRUE),
-			array(array('username', 'qweqwe'), TRUE),
 			array(array('email', 'qweqwe'), TRUE),
 			array(array(NULL, 'qweqwe2'), FALSE),
 			array(array('username', 'qweqwe2'), FALSE),

--- a/tests/tests/auth/model/UserTest.php
+++ b/tests/tests/auth/model/UserTest.php
@@ -18,12 +18,12 @@ class Auth_Model_UserTest extends PHPUnit_Framework_TestCase {
 		return array(
 			array(1, 'id'),
 			array(NULL, 'id'),
-			array('admin', 'email'),
-			array('user', 'email'),
-			array('login21', 'email'),
+			array('admin', 'username'),
+			array('user', 'username'),
+			array('login21', 'username'),
 			array('admin@example.com', 'email'),
 			array('user@example.com', 'email'),
-			array('user@example23', 'email'),
+			array('user@example23', 'username'),
 		);
 	}
 
@@ -33,7 +33,7 @@ class Auth_Model_UserTest extends PHPUnit_Framework_TestCase {
 	 */
 	public function test_unique_key($value, $expected_attribute)
 	{
-		$this->assertEquals($expected_attribute, Model_Auth_User::unique_key($value));
+		$this->assertEquals($expected_attribute, Jam::meta('test_user')->unique_key($value));
 	}
 
 	public function test_complete_login()

--- a/tests/tests/auth/model/UserTest.php
+++ b/tests/tests/auth/model/UserTest.php
@@ -18,12 +18,12 @@ class Auth_Model_UserTest extends PHPUnit_Framework_TestCase {
 		return array(
 			array(1, 'id'),
 			array(NULL, 'id'),
-			array('admin', 'username'),
-			array('user', 'username'),
-			array('login21', 'username'),
+			array('admin', 'email'),
+			array('user', 'email'),
+			array('login21', 'email'),
 			array('admin@example.com', 'email'),
 			array('user@example.com', 'email'),
-			array('user@example23', 'username'),
+			array('user@example23', 'email'),
 		);
 	}
 


### PR DESCRIPTION
- the ability to search by username directly in Jam::find('user', 'username') is lost
- username field and validation extracted into a behaviour so it can be added if needed