### PR TITLE
Load facebook data on "link" event

### DIFF
--- a/classes/Kohana/Auth/Service.php
+++ b/classes/Kohana/Auth/Service.php
@@ -94,6 +94,11 @@ abstract class Kohana_Auth_Service {
 					if ($user->loaded())
 					{
 						$user->_is_new = FALSE;
+
+                        if (Arr::get($this->_config, 'link_user'))
+                        {
+                            $user->load_service_values($this, $data, FALSE);
+                        }
 					}
 				}
 

--- a/classes/Kohana/Auth/Service.php
+++ b/classes/Kohana/Auth/Service.php
@@ -95,7 +95,7 @@ abstract class Kohana_Auth_Service {
 					{
 						$user->_is_new = FALSE;
 
-                        if (Arr::get($this->_config, 'link_user'))
+                        if (Arr::get($this->_config, 'update_user_on_link'))
                         {
                             $user->load_service_values($this, $data, FALSE);
                         }


### PR DESCRIPTION
When loading data for a user that already exits, we didn't fill all the
feilds with data from facebook.