### PR TITLE
Stop deleting expired tokens automatically

### DIFF
--- a/classes/Kohana/Model/Auth/User/Token.php
+++ b/classes/Kohana/Model/Auth/User/Token.php
@@ -71,14 +71,4 @@ class Kohana_Model_Auth_User_Token extends Jam_Model {
 
 		return $this;	
 	}
-
-	public function __construct($id = NULL)
-	{
-		parent::__construct($id);
-
-		if (mt_rand(1, 100) === 1)
-		{
-			Jam::delete($this)->expired()->execute();
-		}
-	}
 }


### PR DESCRIPTION
This should be application logic for a specific application and probably cleared only after some time, not deleting immediately on average in 1% of requests.